### PR TITLE
missing com.zwitserloot dependency ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+JBossBot
+========
+
+The source for 'jbossbot' on irc.freenode.org.
+
+How to build
+============
+
+To build you need to have zwitserloot installed in your local maven repository:
+
+    $ git clone https://github.com/rzwitserloot/com.zwitserloot.json
+    $ cd com.zwitserloot.json
+    $ ant
+    $ mvn install:install-file -Dfile=dist/com.zwitserloot.json.jar -DgroupId=com.zwitserloot.json -DartifactId=json -Dversion=1.0 -Dpackaging=jar
+   
+After that you can build jbossbot:
+
+    $ git clone git://github.com/jbossbot/jbossbot.git
+    $ cd jbossbot
+    $ mvn veirfy
+
+How to run
+==========
+
+You need a registered nick to use for testing. jbossbot will not join
+channels before your user is registered.
+
+Once that is done you need to create a file named
+'jbossbot.properties' which specify the nick and nicksrv password to
+use (you can use 'sample-jbossbot.properties' to see the various
+properties)
+
+After that you should be able to run by doing this:
+
+    $ mvn exec:java -Dexec.mainClass=org.jboss.bot.Main
+
+Other settings
+==============
+
+Use the source...

--- a/sample-jbossbot.properties
+++ b/sample-jbossbot.properties
@@ -1,0 +1,12 @@
+# irc nick and login (must be specified)
+nick=yournick
+nickserv.password=secret
+
+# login name 
+#login=
+
+# Jira setup.
+jira.site.0.url=https://issues.jboss.org/
+jira.site.0.username=someuser
+jira.site.0.password=secret
+jira.site.0.prefixes=JBIDE,TOOLSDOC,JBDS


### PR DESCRIPTION
`mvn verify` results in:

Could not resolve dependencies for project org.jboss.bot:jbossbot:jar:1.0.0-SNAPSHOT: Could not find artifact com.zwitserloot.json:json:jar:1.0

I assume this is manually built from git://github.com/rzwitserloot/com.zwitserloot.json.git since I cannot seem to find this artifact in maven central nor jboss repos ?
